### PR TITLE
Restrict pairing for literals/escaped char

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ Once installed, the "plugin" will automatically insert closing pairs whenever yo
 []
 {}
 ```
-
+Escaped character wont be auto paired to let you compose literals with ease.
+try typing:
+```bash
+sed "s/\"\'//g"
+```
 It will also delete pairs using `C-h` and `Baskspace`.
 
 For instance, try typing and then deleting the following:

--- a/README.md
+++ b/README.md
@@ -38,11 +38,14 @@ Once installed, the "plugin" will automatically insert closing pairs whenever yo
 []
 {}
 ```
-Escaped character wont be auto paired to let you compose literals with ease.
-try typing:
+
+Escaped characters won't be auto paired to let you compose literals with ease.
+Try typing:
+
 ```bash
 sed "s/\"\'//g"
 ```
+
 It will also delete pairs using `C-h` and `Baskspace`.
 
 For instance, try typing and then deleting the following:

--- a/autopairs.sh
+++ b/autopairs.sh
@@ -10,18 +10,17 @@ function __autopair() {
   local closing_char="$3"
   local cursor_char="${READLINE_LINE:READLINE_POINT:1}"
   local previous_char="${READLINE_LINE:READLINE_POINT-1:1}"
-  local num_of_char
+  local num_of_char="${READLINE_LINE//\\$typed_char}"
 
   local s
   s="${READLINE_LINE::READLINE_POINT}"
 
-  num_of_char="${READLINE_LINE//\\$typed_char}"
-  num_of_char="${num_of_char//[^$typed_char]/}"
-  num_of_char="${#num_of_char}"
-
   if [[ "$previous_char"  == "\\" ]]; then
     s+="$typed_char"
   elif [[ "$opening_char" == "$closing_char" ]]; then
+    num_of_char="${num_of_char//[^$typed_char]/}"
+    num_of_char="${#num_of_char}"
+
     if [[ "$((num_of_char % 2))" -eq 1 ]]; then
       s+="$typed_char"
     elif [[ "$cursor_char" == "$closing_char" ]]; then

--- a/autopairs.sh
+++ b/autopairs.sh
@@ -9,20 +9,29 @@ function __autopair() {
   local opening_char="$2"
   local closing_char="$3"
   local cursor_char="${READLINE_LINE:READLINE_POINT:1}"
-  local num_of_char
+  local previous_char="${READLINE_LINE:READLINE_POINT-1:1}"
+  local match
 
   local s
   s="${READLINE_LINE::READLINE_POINT}"
 
-  if [[ "$opening_char" == "$closing_char" ]]; then
-    num_of_char="${READLINE_LINE//[^$typed_char]/}"
-    num_of_char="${#num_of_char}"
+  match="$(command grep -oE "\\${typed_char}" <<< "${READLINE_LINE}" || true )"
+  if [[ "${opening_char}" == "${closing_char}" ]]; then
+    match="$(command grep -oE "\\\\${typed_char}" <<< "${READLINE_LINE}" || true )"
+  fi
+  match="$(command tr -d '\\n' <<< "$match")"
 
-    if [[ "$((num_of_char % 2))" -eq 1 ]]; then
+  local literals="${match//[^${typed_char}]/}"
+  local quotes_char="${READLINE_LINE//[^$typed_char]/}"
+
+  if [[ "$previous_char"  == "\\" ]]; then
+    s+="${typed_char}"
+  elif [[ "$opening_char" == "$closing_char" ]]; then
+    if [[ "$(((${#quotes_char} - ${#literals}) % 2))" -eq 1 ]]; then
       s+="$typed_char"
     elif [[ "$cursor_char" == "$closing_char" ]]; then
       :
-    elif [[ "$((num_of_char % 2))" -eq 0 ]]; then
+    elif [[ "$(((${#quotes_char} - ${#literals}) % 2))" -eq 0 ]]; then
       s+="$typed_char$typed_char"
     fi
   elif [[ "$typed_char" == "$opening_char" ]]; then

--- a/autopairs.sh
+++ b/autopairs.sh
@@ -15,11 +15,11 @@ function __autopair() {
   local s
   s="${READLINE_LINE::READLINE_POINT}"
 
-  num_of_char="${READLINE_LINE//\\$typed_char}"
+  num_of_char="${READLINE_LINE//\\${typed_char}}"
   num_of_char="${num_of_char//[^${typed_char}]/}"
 
   if [[ "$previous_char"  == "\\" ]]; then
-    s+="${typed_char}"
+    s+="$typed_char"
   elif [[ "$opening_char" == "$closing_char" ]]; then
     if [[ "$(( ${#num_of_char} % 2 ))" -eq 1 ]]; then
       s+="$typed_char"

--- a/autopairs.sh
+++ b/autopairs.sh
@@ -10,7 +10,7 @@ function __autopair() {
   local closing_char="$3"
   local cursor_char="${READLINE_LINE:READLINE_POINT:1}"
   local previous_char="${READLINE_LINE:READLINE_POINT-1:1}"
-  local num_of_char="${READLINE_LINE//\\$typed_char}"
+  local num_of_char
 
   local s
   s="${READLINE_LINE::READLINE_POINT}"
@@ -18,6 +18,7 @@ function __autopair() {
   if [[ "$previous_char"  == "\\" ]]; then
     s+="$typed_char"
   elif [[ "$opening_char" == "$closing_char" ]]; then
+    num_of_char="${READLINE_LINE//\\$typed_char}"
     num_of_char="${num_of_char//[^$typed_char]/}"
     num_of_char="${#num_of_char}"
 

--- a/autopairs.sh
+++ b/autopairs.sh
@@ -15,17 +15,18 @@ function __autopair() {
   local s
   s="${READLINE_LINE::READLINE_POINT}"
 
-  num_of_char="${READLINE_LINE//\\${typed_char}}"
-  num_of_char="${num_of_char//[^${typed_char}]/}"
+  num_of_char="${READLINE_LINE//\\$typed_char}"
+  num_of_char="${num_of_char//[^$typed_char]/}"
+  num_of_char="${#num_of_char}"
 
   if [[ "$previous_char"  == "\\" ]]; then
     s+="$typed_char"
   elif [[ "$opening_char" == "$closing_char" ]]; then
-    if [[ "$(( ${#num_of_char} % 2 ))" -eq 1 ]]; then
+    if [[ "$((num_of_char % 2))" -eq 1 ]]; then
       s+="$typed_char"
     elif [[ "$cursor_char" == "$closing_char" ]]; then
       :
-    elif [[ "$(( ${#num_of_char} % 2 ))" -eq 0 ]]; then
+    elif [[ "$((num_of_char % 2))" -eq 0 ]]; then
       s+="$typed_char$typed_char"
     fi
   elif [[ "$typed_char" == "$opening_char" ]]; then

--- a/autopairs.sh
+++ b/autopairs.sh
@@ -10,28 +10,22 @@ function __autopair() {
   local closing_char="$3"
   local cursor_char="${READLINE_LINE:READLINE_POINT:1}"
   local previous_char="${READLINE_LINE:READLINE_POINT-1:1}"
-  local match
+  local num_of_char
 
   local s
   s="${READLINE_LINE::READLINE_POINT}"
 
-  match="$(command grep -oE "\\${typed_char}" <<< "${READLINE_LINE}" || true )"
-  if [[ "${opening_char}" == "${closing_char}" ]]; then
-    match="$(command grep -oE "\\\\${typed_char}" <<< "${READLINE_LINE}" || true )"
-  fi
-  match="$(command tr -d '\\n' <<< "$match")"
-
-  local literals="${match//[^${typed_char}]/}"
-  local quotes_char="${READLINE_LINE//[^$typed_char]/}"
+  num_of_char="${READLINE_LINE//\\$typed_char}"
+  num_of_char="${num_of_char//[^${typed_char}]/}"
 
   if [[ "$previous_char"  == "\\" ]]; then
     s+="${typed_char}"
   elif [[ "$opening_char" == "$closing_char" ]]; then
-    if [[ "$(((${#quotes_char} - ${#literals}) % 2))" -eq 1 ]]; then
+    if [[ "$(( ${#num_of_char} % 2 ))" -eq 1 ]]; then
       s+="$typed_char"
     elif [[ "$cursor_char" == "$closing_char" ]]; then
       :
-    elif [[ "$(((${#quotes_char} - ${#literals}) % 2))" -eq 0 ]]; then
+    elif [[ "$(( ${#num_of_char} % 2 ))" -eq 0 ]]; then
       s+="$typed_char$typed_char"
     fi
   elif [[ "$typed_char" == "$opening_char" ]]; then


### PR DESCRIPTION
This will exclude escaped registered pairs from auto-pairing. ideal for composing a regex